### PR TITLE
Vercel fix

### DIFF
--- a/src/Components/Loading/Loading.js
+++ b/src/Components/Loading/Loading.js
@@ -1,6 +1,6 @@
 import React from "react";
 import spinner from '../../assets/loading-spinner.png'
-import title from '../../assets/loading-title.png'
+import title from '../../assets/Loading-title.png'
 import './Loading.css'
 
 const Loading = () => {


### PR DESCRIPTION
Changed loading component's title image name to match what's on Github since Github won't recognize it has been changed